### PR TITLE
Feature/pkt fwd do not start if not configured

### DIFF
--- a/packet-forwarder/files/lora_pkt_fwd.init
+++ b/packet-forwarder/files/lora_pkt_fwd.init
@@ -60,9 +60,18 @@ generate_global_conf()
 	uci set lora-global.global.freq_plan="$FREQ"
 	uci commit
 
+	SRV_ADDR=$(uci get lora-global.gateway_conf.server_address 2> /dev/null)
+	if [ -z $SRV_ADDR ]
+	then
+		logger "packet forwarder not configured, do not start it"
+		exit 1
+	else
+		gen_lora_global_conf
+	fi
+
 	logger "Generate /etc/lora/local_conf.json"
 	logger "Generate /etc/lora/global_conf.json"
-	gen_lora_global_conf
+
 }
 
 service_triggers()
@@ -81,12 +90,15 @@ reload_service()
 
 start_service()
 {
-	logger "Reset SX1301"
-	reset_sx1301_board
+
 
 	set_gateway_ID
 
 	generate_global_conf
+
+	logger "Reset SX1301"
+	reset_sx1301_board
+
 	logger "Starting LoRa packet forwarder"
 	procd_open_instance
 

--- a/packet-forwarder/files/lora_pkt_fwd.init
+++ b/packet-forwarder/files/lora_pkt_fwd.init
@@ -104,7 +104,7 @@ start_service()
 
 	procd_set_param command $PROG
 
-	procd_set_param respawn
+	procd_set_param respawn 3600 5 0
 
 	procd_set_param stdout 0
 	procd_set_param stderr 1

--- a/packet-forwarder/files/lora_pkt_fwd.init
+++ b/packet-forwarder/files/lora_pkt_fwd.init
@@ -61,7 +61,7 @@ generate_global_conf()
 	uci commit
 
 	SRV_ADDR=$(uci get lora-global.gateway_conf.server_address 2> /dev/null)
-	if [ -z $SRV_ADDR ]
+	if [ -z "$SRV_ADDR" ]
 	then
 		logger "packet forwarder not configured, do not start it"
 		exit 1


### PR DESCRIPTION
This PR change packet-forwarder behaviour to allow basic station usage and improve resilience : 

- If no server IP configured, we don't start the packet forwarder
- We reset radio interface only if we will start it
- Improve procd process respawn to always try and to not stop after a while (see https://openwrt.org/docs/guide-developer/procd-init-scripts)
