### PR TITLE
Fix/lora pkt fwd init soft exit

### DIFF
--- a/packet-forwarder/Makefile
+++ b/packet-forwarder/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=packet-forwarder
 PKG_VERSION:=3.1.0-wifx
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/packet_forwarder-$(PKG_VERSION)
 PKG_SOURCE:=v$(PKG_VERSION).tar.gz

--- a/packet-forwarder/files/lora_pkt_fwd.init
+++ b/packet-forwarder/files/lora_pkt_fwd.init
@@ -64,7 +64,7 @@ generate_global_conf()
 	if [ -z "$SRV_ADDR" ]
 	then
 		logger "packet forwarder not configured, do not start it"
-		exit 1
+		return 1
 	else
 		gen_lora_global_conf
 	fi
@@ -94,7 +94,7 @@ start_service()
 
 	set_gateway_ID
 
-	generate_global_conf
+	generate_global_conf || return 1
 
 	logger "Reset SX1301"
 	reset_sx1301_board


### PR DESCRIPTION
This PR fix init script exit in case lora-packet-forwader is not configure. 

First version was doing a plain exit, which seems to confuse procd, unable after that to detect change done in uci, with a return 1, it works way better (and seems the way used in most others core packages). 